### PR TITLE
Dark mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /node_modules
 .DS_STORE
 .lycheecache
+.superpowers/

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 .DS_STORE
 .lycheecache
 .superpowers/
+test-results/
+docs/

--- a/404.html
+++ b/404.html
@@ -9,6 +9,7 @@
     />
     <meta name="description" content="404 Error | Page Not Found" />
     <meta name="robots" content="noindex" />
+    <script src="/assets/js/theme-init.js"></script>
     <link rel="stylesheet" href="/assets/css/main.css" />
     <link rel="stylesheet" href="/assets/css/familytree.css" />
     <link rel="icon" href="/images/icons/favicon-50_w.webp" />

--- a/README.md
+++ b/README.md
@@ -20,10 +20,10 @@ Install tools:
 mise install
 ```
 
-Run live server:
+Run dev server:
 
 ```shell
-bunx live-server
+bunx browser-sync start --server --no-open --no-notify
 ```
 
 Run image generator script:

--- a/assets/css/familytree.css
+++ b/assets/css/familytree.css
@@ -22,6 +22,7 @@
   --color-photo-bg: #2a2a2e;
 }
 
+/* Same values as [data-theme="dark"] above. Update both when changing dark colors. */
 @media (prefers-color-scheme: dark) {
   :root:not([data-theme="light"]) {
     --color-scrollbar-track: #2a2a2e;

--- a/assets/css/familytree.css
+++ b/assets/css/familytree.css
@@ -1,5 +1,40 @@
 /* Family Tree */
 
+:root {
+  --color-scrollbar-track: #e4e4e4;
+  --color-scrollbar-thumb: #212121;
+  --color-scrollbar-hover: #d5b14c;
+  --color-connector: #cccccc;
+  --color-connector-hover: #fbba00;
+  --color-member-text: #666666;
+  --color-photo-border: lightgrey;
+  --color-photo-bg: white;
+}
+
+[data-theme="dark"] {
+  --color-scrollbar-track: #2a2a2e;
+  --color-scrollbar-thumb: #94b8c8;
+  --color-scrollbar-hover: #d5b14c;
+  --color-connector: #3a3a42;
+  --color-connector-hover: #fbba00;
+  --color-member-text: #b0b0b8;
+  --color-photo-border: #3a3a42;
+  --color-photo-bg: #2a2a2e;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme="light"]) {
+    --color-scrollbar-track: #2a2a2e;
+    --color-scrollbar-thumb: #94b8c8;
+    --color-scrollbar-hover: #d5b14c;
+    --color-connector: #3a3a42;
+    --color-connector-hover: #fbba00;
+    --color-member-text: #b0b0b8;
+    --color-photo-border: #3a3a42;
+    --color-photo-bg: #2a2a2e;
+  }
+}
+
 .genealogy-scroll::-webkit-scrollbar {
   width: 5px;
   height: 8px;
@@ -7,17 +42,17 @@
 
 .genealogy-scroll::-webkit-scrollbar-track {
   border-radius: 10px;
-  background-color: #e4e4e4;
+  background-color: var(--color-scrollbar-track);
 }
 
 .genealogy-scroll::-webkit-scrollbar-thumb {
-  background: #212121;
+  background: var(--color-scrollbar-thumb);
   border-radius: 10px;
   transition: 0.5s;
 }
 
 .genealogy-scroll::-webkit-scrollbar-thumb:hover {
-  background: #d5b14c;
+  background: var(--color-scrollbar-hover);
   transition: 0.5s;
 }
 
@@ -55,7 +90,7 @@
   position: absolute;
   top: 0;
   right: 50%;
-  border-top: 2px solid #ccc;
+  border-top: 2px solid var(--color-connector);
   width: 50%;
   height: 18px;
 }
@@ -63,7 +98,7 @@
 .genealogy-tree li::after {
   right: auto;
   left: 50%;
-  border-left: 2px solid #ccc;
+  border-left: 2px solid var(--color-connector);
 }
 
 .genealogy-tree li:only-child::after,
@@ -81,7 +116,7 @@
 }
 
 .genealogy-tree li:last-child::before {
-  border-right: 2px solid #ccc;
+  border-right: 2px solid var(--color-connector);
   border-radius: 0 5px 0 0;
   -webkit-border-radius: 0 5px 0 0;
   -moz-border-radius: 0 5px 0 0;
@@ -98,7 +133,7 @@
   position: absolute;
   top: 0;
   left: 50%;
-  border-left: 2px solid #ccc;
+  border-left: 2px solid var(--color-connector);
   width: 0;
   height: 20px;
 }
@@ -111,7 +146,7 @@
 .genealogy-tree li a:hover + ul li::before,
 .genealogy-tree li a:hover + ul::before,
 .genealogy-tree li a:hover + ul ul::before {
-  border-color: #fbba00;
+  border-color: var(--color-connector-hover);
 }
 
 /*--------------memeber-card-design----------*/
@@ -132,8 +167,8 @@
   width: 8vw;
   height: auto;
   border-radius: 6px;
-  border: 1px solid lightgrey;
-  background-color: white;
+  border: 1px solid var(--color-photo-border);
+  background-color: var(--color-photo-bg);
   z-index: 1;
 }
 
@@ -144,7 +179,7 @@
 
 .member-details {
   text-decoration: none;
-  color: #666;
+  color: var(--color-member-text);
   font-family: arial, verdana, tahoma;
   font-size: 11px;
   border-radius: 5px;

--- a/assets/css/guitartab.css
+++ b/assets/css/guitartab.css
@@ -14,6 +14,7 @@
   --color-focus-border: #60a5fa;
 }
 
+/* Same values as [data-theme="dark"] above. Update both when changing dark colors. */
 @media (prefers-color-scheme: dark) {
   :root:not([data-theme="light"]) {
     --color-bg-lightest: #1e293b;

--- a/assets/css/guitartab.css
+++ b/assets/css/guitartab.css
@@ -4,12 +4,14 @@
   --color-bg-lightest: #f0f9ff;
   --color-bg-lighter: #e0f2fe;
   --color-text-darkest: #0c4a6e;
+  --color-focus-border: #3b82f6;
 }
 
 [data-theme="dark"] {
   --color-bg-lightest: #1e293b;
   --color-bg-lighter: #334155;
   --color-text-darkest: #e2e8f0;
+  --color-focus-border: #60a5fa;
 }
 
 @media (prefers-color-scheme: dark) {
@@ -17,6 +19,7 @@
     --color-bg-lightest: #1e293b;
     --color-bg-lighter: #334155;
     --color-text-darkest: #e2e8f0;
+    --color-focus-border: #60a5fa;
   }
 }
 
@@ -29,7 +32,7 @@
 
 :focus {
   outline: none;
-  box-shadow: inset 0 0 0 2px #3b82f6;
+  box-shadow: inset 0 0 0 2px var(--color-focus-border);
 }
 
 /* General styling */

--- a/assets/css/guitartab.css
+++ b/assets/css/guitartab.css
@@ -1,16 +1,22 @@
 :root {
   --header-height: 10%;
   --main-height: calc(100% - var(--header-height));
-  --lightest-bg-color: #f0f9ff;
-  --lighter-bg-color: #e0f2fe;
-  --darkest-text-color: #0c4a6e;
+  --color-bg-lightest: #f0f9ff;
+  --color-bg-lighter: #e0f2fe;
+  --color-text-darkest: #0c4a6e;
+}
+
+[data-theme="dark"] {
+  --color-bg-lightest: #1e293b;
+  --color-bg-lighter: #334155;
+  --color-text-darkest: #e2e8f0;
 }
 
 @media (prefers-color-scheme: dark) {
-  :root {
-    --lightest-bg-color: #1e293b;
-    --lighter-bg-color: #334155;
-    --darkest-text-color: #e2e8f0;
+  :root:not([data-theme="light"]) {
+    --color-bg-lightest: #1e293b;
+    --color-bg-lighter: #334155;
+    --color-text-darkest: #e2e8f0;
   }
 }
 
@@ -30,8 +36,8 @@
 body {
   margin: 0;
   height: 100vh;
-  background-color: var(--lightest-bg-color);
-  color: var(--darkest-text-color);
+  background-color: var(--color-bg-lightest);
+  color: var(--color-text-darkest);
   font-family: "Nunito", "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
 }
 
@@ -52,7 +58,7 @@ body {
 
 select,
 option {
-  color: var(--darkest-text-color);
+  color: var(--color-text-darkest);
   font-family: "Nunito", "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
 }
 
@@ -66,8 +72,8 @@ textarea {
   height: 100%;
   max-height: 100%;
   resize: none;
-  background-color: var(--lighter-bg-color);
-  color: var(--darkest-text-color);
+  background-color: var(--color-bg-lighter);
+  color: var(--color-text-darkest);
 }
 
 #wrapper {

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -38,6 +38,7 @@
   --color-shadow: rgba(0, 0, 0, 0.1);
   --color-shadow-strong: rgba(0, 0, 0, 0.3);
   --color-focus-ring: rgba(37, 99, 235, 0.18);
+  --color-focus-border: #3b82f6;
   --color-accent: #4b7bec;
   --color-accent-bg: rgba(75, 123, 236, 0.08);
 }
@@ -61,6 +62,7 @@
   --color-shadow: rgba(200, 210, 230, 0.12);
   --color-shadow-strong: rgba(200, 210, 230, 0.18);
   --color-focus-ring: rgba(96, 165, 250, 0.3);
+  --color-focus-border: #60a5fa;
   --color-accent: #6fa0d8;
   --color-accent-bg: rgba(111, 160, 216, 0.1);
 }
@@ -86,6 +88,7 @@
     --color-shadow: rgba(200, 210, 230, 0.12);
     --color-shadow-strong: rgba(200, 210, 230, 0.18);
     --color-focus-ring: rgba(96, 165, 250, 0.3);
+    --color-focus-border: #60a5fa;
     --color-accent: #6fa0d8;
     --color-accent-bg: rgba(111, 160, 216, 0.1);
   }

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -892,8 +892,6 @@ div.project-card {
   overflow: hidden;
 
   & a > img {
-    border-top-left-radius: 0.5rem;
-    border-top-right-radius: 0.5rem;
     max-width: 100%;
   }
 

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -36,11 +36,14 @@
   --color-code-bg: rgba(144, 144, 144, 0.075);
   --color-menu-overlay: rgba(255, 255, 255, 0.9);
   --color-hamburger-bg: rgba(255, 255, 255, 0.5);
+  --color-shadow: rgba(0, 0, 0, 0.1);
+  --color-shadow-strong: rgba(0, 0, 0, 0.3);
+  --color-focus-ring: rgba(37, 99, 235, 0.18);
 }
 
 [data-theme="dark"] {
   color-scheme: dark;
-  --color-navbar-link: #94b8c8;
+  --color-navbar-link: #e2e8f0;
   --color-blue-text: #6fa0d8;
   --color-bg: #1e1e22;
   --color-bg-surface: #2a2a2e;
@@ -48,19 +51,22 @@
   --color-text-primary: #e2e8f0;
   --color-text-secondary: #b0b0b8;
   --color-text-link: #b0b0b8;
-  --color-border: #3a3a42;
+  --color-border: #65656f;
   --color-border-light: #2a2a2e;
   --color-heading-green: #5aab55;
   --color-heading-blue: #6fa0d8;
   --color-code-bg: rgba(255, 255, 255, 0.06);
   --color-menu-overlay: rgba(0, 0, 0, 0.7);
   --color-hamburger-bg: rgba(0, 0, 0, 0.3);
+  --color-shadow: rgba(200, 210, 230, 0.12);
+  --color-shadow-strong: rgba(200, 210, 230, 0.18);
+  --color-focus-ring: rgba(96, 165, 250, 0.3);
 }
 
 @media (prefers-color-scheme: dark) {
   :root:not([data-theme="light"]) {
     color-scheme: dark;
-    --color-navbar-link: #94b8c8;
+    --color-navbar-link: #e2e8f0;
     --color-blue-text: #6fa0d8;
     --color-bg: #1e1e22;
     --color-bg-surface: #2a2a2e;
@@ -68,13 +74,16 @@
     --color-text-primary: #e2e8f0;
     --color-text-secondary: #b0b0b8;
     --color-text-link: #b0b0b8;
-    --color-border: #3a3a42;
+    --color-border: #65656f;
     --color-border-light: #2a2a2e;
     --color-heading-green: #5aab55;
     --color-heading-blue: #6fa0d8;
     --color-code-bg: rgba(255, 255, 255, 0.06);
     --color-menu-overlay: rgba(0, 0, 0, 0.7);
     --color-hamburger-bg: rgba(0, 0, 0, 0.3);
+    --color-shadow: rgba(200, 210, 230, 0.12);
+    --color-shadow-strong: rgba(200, 210, 230, 0.18);
+    --color-focus-ring: rgba(96, 165, 250, 0.3);
   }
 }
 
@@ -1247,10 +1256,20 @@ body.is-preload .affiliated-tiles-grid .affiliated-tile {
 }
 
 @media (prefers-color-scheme: dark) {
-  :root:not([data-theme="light"]) #side-menu-btn nav ul li a[href="#menu"]:before {
+  :root:not([data-theme="light"])
+    #side-menu-btn
+    nav
+    ul
+    li
+    a[href="#menu"]:before {
     background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='100' height='100' viewBox='0 0 100 100' preserveAspectRatio='none'%3E%3Cstyle%3Eline %7B stroke-width: 8px%3B stroke: %23cccccc%3B %7D%3C/style%3E%3Cline x1='0' y1='25' x2='100' y2='25' /%3E%3Cline x1='0' y1='50' x2='100' y2='50' /%3E%3Cline x1='0' y1='75' x2='100' y2='75' /%3E%3C/svg%3E");
   }
-  :root:not([data-theme="light"]) #side-menu-btn nav ul li a[href="#menu"]:after {
+  :root:not([data-theme="light"])
+    #side-menu-btn
+    nav
+    ul
+    li
+    a[href="#menu"]:after {
     background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='100' height='100' viewBox='0 0 100 100' preserveAspectRatio='none'%3E%3Cstyle%3Eline %7B stroke-width: 8px%3B stroke: %23aaaaaa%3B %7D%3C/style%3E%3Cline x1='0' y1='25' x2='100' y2='25' /%3E%3Cline x1='0' y1='50' x2='100' y2='50' /%3E%3Cline x1='0' y1='75' x2='100' y2='75' /%3E%3C/svg%3E");
   }
 }
@@ -1671,8 +1690,8 @@ form[name="contact"] .check-row label {
 }
 
 .theme-toggle-btn svg {
-  width: 1.2em;
-  height: 1.2em;
+  width: 1.8em;
+  height: 1.8em;
   display: block;
 }
 
@@ -1722,4 +1741,3 @@ form[name="contact"] .check-row label {
   display: flex;
   align-items: center;
 }
-

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -33,8 +33,8 @@
   --color-heading-green: #23751f;
   --color-heading-blue: #0e4194;
   --color-code-bg: rgba(144, 144, 144, 0.075);
-  --color-menu-overlay: rgba(255, 255, 255, 0.9);
-  --color-hamburger-bg: rgba(255, 255, 255, 0.5);
+  --color-menu-overlay: rgba(200, 200, 200, 0.7);
+  --color-hamburger-bg: rgba(255, 255, 255, 0.9);
   --color-shadow: rgba(0, 0, 0, 0.1);
   --color-shadow-strong: rgba(0, 0, 0, 0.3);
   --color-focus-ring: rgba(37, 99, 235, 0.18);
@@ -57,7 +57,7 @@
   --color-heading-blue: #6fa0d8;
   --color-code-bg: rgba(255, 255, 255, 0.06);
   --color-menu-overlay: rgba(0, 0, 0, 0.7);
-  --color-hamburger-bg: rgba(0, 0, 0, 0.3);
+  --color-hamburger-bg: rgba(0, 0, 0, 0.9);
   --color-shadow: rgba(200, 210, 230, 0.12);
   --color-shadow-strong: rgba(200, 210, 230, 0.18);
   --color-focus-ring: rgba(96, 165, 250, 0.3);
@@ -82,7 +82,7 @@
     --color-heading-blue: #6fa0d8;
     --color-code-bg: rgba(255, 255, 255, 0.06);
     --color-menu-overlay: rgba(0, 0, 0, 0.7);
-    --color-hamburger-bg: rgba(0, 0, 0, 0.3);
+    --color-hamburger-bg: rgba(0, 0, 0, 0.9);
     --color-shadow: rgba(200, 210, 230, 0.12);
     --color-shadow-strong: rgba(200, 210, 230, 0.18);
     --color-focus-ring: rgba(96, 165, 250, 0.3);
@@ -1200,6 +1200,7 @@ body.is-preload .affiliated-tiles-grid .affiliated-tile {
   background-color: var(--color-hamburger-bg);
   border-radius: 4px;
   border: solid 1px var(--color-border);
+  box-shadow: 0 1px 6px rgba(255, 255, 255, 0.3);
   font-size: 0.8em;
   font-weight: 900;
   letter-spacing: 0.35em;
@@ -1442,6 +1443,8 @@ body::before {
 body.is-menu-visible::before {
   opacity: 1;
   visibility: visible;
+  backdrop-filter: blur(6px);
+  -webkit-backdrop-filter: blur(6px);
 }
 body.is-menu-visible #menu {
   transform: translateX(0);
@@ -1683,7 +1686,7 @@ form[name="contact"] .check-row label {
   background: none;
   border: none;
   cursor: pointer;
-  padding: 0.4em;
+  padding: 0.7em;
   color: var(--color-navbar-link);
   display: flex;
   align-items: center;
@@ -1735,4 +1738,3 @@ form[name="contact"] .check-row label {
   color: #ffffff;
   z-index: 1;
 }
-

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -888,7 +888,7 @@ div.tiles-or-card-row {
 div.project-card {
   border: 1px solid var(--color-border);
   border-radius: 0.5rem;
-  box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1);
+  box-shadow: 0 1px 3px 0 var(--color-shadow);
 
   & a > img {
     border-top-left-radius: 0.5rem;
@@ -1516,7 +1516,7 @@ form[name="contact"] {
   color: var(--color-text);
   border: 1px solid var(--color-border);
   border-radius: 14px;
-  box-shadow: 0 12px 28px rgba(0, 0, 0, 0.08);
+  box-shadow: 0 12px 28px var(--color-shadow);
 }
 
 /* Table layout -> spaced rows */

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -888,7 +888,8 @@ div.tiles-or-card-row {
 div.project-card {
   border: 1px solid var(--color-border);
   border-radius: 0.5rem;
-  box-shadow: 0 1px 3px 0 var(--color-shadow);
+  box-shadow: 0 2px 8px 0 var(--color-shadow);
+  overflow: hidden;
 
   & a > img {
     border-top-left-radius: 0.5rem;

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1699,13 +1699,23 @@ form[name="contact"] .check-row label {
   }
 }
 
+/* Side menu theme toggle */
+#menu > .theme-toggle-btn {
+  position: absolute;
+  top: 1em;
+  right: 1em;
+  background: rgba(255, 255, 255, 0.1);
+  border-radius: 6px;
+  color: #ffffff;
+  z-index: 1;
+}
+
 /* Navbar inner layout for toggle placement */
 #navbar .navbar-inner {
   display: flex;
   align-items: center;
   justify-content: center;
   height: 100%;
-  position: relative;
 }
 
 #navbar .navbar-inner ul {
@@ -1713,27 +1723,3 @@ form[name="contact"] .check-row label {
   align-items: center;
 }
 
-#navbar .navbar-toggle-slot {
-  position: absolute;
-  right: 1em;
-  top: 50%;
-  transform: translateY(-50%);
-}
-
-/* Side menu theme toggle row */
-li.theme-toggle-row {
-  display: flex;
-  align-items: center;
-  padding: 0.75em 0;
-  border-top: solid 1px rgba(255, 255, 255, 0.15);
-  gap: 0.75em;
-}
-
-li.theme-toggle-row label {
-  color: inherit;
-  font-size: 0.9em;
-}
-
-li.theme-toggle-row .theme-toggle-btn {
-  color: #ffffff;
-}

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -393,6 +393,17 @@ table {
   top: 0;
   height: var(--navbar-height);
 }
+@media screen and (min-width: 981px) {
+  #navbar {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+  #navbar .theme-toggle-btn {
+    position: absolute;
+    right: 1em;
+  }
+}
 #subnavbar {
   top: var(--navbar-height);
   height: var(--subnavbar-height);
@@ -1171,6 +1182,13 @@ div.project-card__more-btn {
 body.is-preload .affiliated-tiles-grid .affiliated-tile {
   transform: scale(0.9);
   opacity: 0;
+}
+
+/* Hide hamburger on desktop where navbar is visible */
+@media screen and (min-width: 981px) {
+  #side-menu-btn {
+    display: none;
+  }
 }
 
 /* Side Menu */

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -24,7 +24,6 @@
   --color-navbar-link: #4f4f4f;
   --color-blue-text: #0b4f6c;
   --color-bg: #ffffff;
-  --color-bg-surface: #f6f6f6;
   --color-bg-footer: #f6f6f6;
   --color-text-primary: #383838;
   --color-text-secondary: #585858;
@@ -39,6 +38,8 @@
   --color-shadow: rgba(0, 0, 0, 0.1);
   --color-shadow-strong: rgba(0, 0, 0, 0.3);
   --color-focus-ring: rgba(37, 99, 235, 0.18);
+  --color-accent: #4b7bec;
+  --color-accent-bg: rgba(75, 123, 236, 0.08);
 }
 
 [data-theme="dark"] {
@@ -46,7 +47,6 @@
   --color-navbar-link: #e2e8f0;
   --color-blue-text: #6fa0d8;
   --color-bg: #1e1e22;
-  --color-bg-surface: #2a2a2e;
   --color-bg-footer: #16161a;
   --color-text-primary: #e2e8f0;
   --color-text-secondary: #b0b0b8;
@@ -61,15 +61,17 @@
   --color-shadow: rgba(200, 210, 230, 0.12);
   --color-shadow-strong: rgba(200, 210, 230, 0.18);
   --color-focus-ring: rgba(96, 165, 250, 0.3);
+  --color-accent: #6fa0d8;
+  --color-accent-bg: rgba(111, 160, 216, 0.1);
 }
 
+/* Same values as [data-theme="dark"] above. Update both when changing dark colors. */
 @media (prefers-color-scheme: dark) {
   :root:not([data-theme="light"]) {
     color-scheme: dark;
     --color-navbar-link: #e2e8f0;
     --color-blue-text: #6fa0d8;
     --color-bg: #1e1e22;
-    --color-bg-surface: #2a2a2e;
     --color-bg-footer: #16161a;
     --color-text-primary: #e2e8f0;
     --color-text-secondary: #b0b0b8;
@@ -84,6 +86,8 @@
     --color-shadow: rgba(200, 210, 230, 0.12);
     --color-shadow-strong: rgba(200, 210, 230, 0.18);
     --color-focus-ring: rgba(96, 165, 250, 0.3);
+    --color-accent: #6fa0d8;
+    --color-accent-bg: rgba(111, 160, 216, 0.1);
   }
 }
 
@@ -487,8 +491,8 @@ table {
 #footer {
   .icons a:hover,
   .icons a:focus-visible {
-    border-color: #4b7bec;
-    background: rgba(75, 123, 236, 0.08);
+    border-color: var(--color-accent);
+    background: var(--color-accent-bg);
     outline: none;
   }
 }
@@ -1080,7 +1084,7 @@ div.project-card__more-btn {
 }
 
 .hobby-card:focus-visible {
-  outline: 3px solid #4a90d9;
+  outline: 3px solid var(--color-focus-border, #4a90d9);
   outline-offset: 2px;
 }
 
@@ -1502,18 +1506,18 @@ body.is-menu-visible #menu .close {
 
 /* Contact form */
 form[name="contact"] {
-  --color-bg: #fff;
-  --color-text: #111827;
-  --color-muted: #6b7280;
-  --color-border: rgba(17, 24, 39, 0.14);
-  --color-border-2: rgba(17, 24, 39, 0.22);
-  --color-focus: #2563eb;
+  --form-bg: #fff;
+  --form-text: #111827;
+  --form-muted: #6b7280;
+  --form-border: rgba(17, 24, 39, 0.14);
+  --form-border-2: rgba(17, 24, 39, 0.22);
+  --form-focus: #2563eb;
 
   margin: 0 auto 2rem;
   padding: 1.25rem;
-  background: var(--color-bg);
-  color: var(--color-text);
-  border: 1px solid var(--color-border);
+  background: var(--form-bg);
+  color: var(--form-text);
+  border: 1px solid var(--form-border);
   border-radius: 14px;
   box-shadow: 0 12px 28px var(--color-shadow);
 }
@@ -1546,10 +1550,10 @@ form[name="contact"] textarea {
   width: 100%;
   box-sizing: border-box;
   padding: 0.7rem 0.85rem;
-  border: 1px solid var(--color-border-2);
+  border: 1px solid var(--form-border-2);
   border-radius: 10px;
-  background: var(--color-bg);
-  color: var(--color-text);
+  background: var(--form-bg);
+  color: var(--form-text);
   outline: 0;
   transition:
     border-color 0.15s ease,
@@ -1563,13 +1567,13 @@ form[name="contact"] textarea {
 
 form[name="contact"] input::placeholder,
 form[name="contact"] textarea::placeholder {
-  color: var(--color-muted);
+  color: var(--form-muted);
 }
 
 form[name="contact"] input[type="text"]:focus-visible,
 form[name="contact"] input[type="email"]:focus-visible,
 form[name="contact"] textarea:focus-visible {
-  border-color: var(--color-focus);
+  border-color: var(--form-focus);
   box-shadow: 0 0 0 4px var(--color-focus-ring);
 }
 
@@ -1579,7 +1583,7 @@ form[name="contact"] td:nth-child(2) input[type="checkbox"] {
 }
 form[name="contact"] td:nth-child(2) input[type="checkbox"] + label {
   font-weight: 500;
-  color: var(--color-text);
+  color: var(--form-text);
 }
 form[name="contact"] td:nth-child(2) br {
   line-height: 1.7;
@@ -1653,22 +1657,23 @@ form[name="contact"] .check-row label {
 
 /* Contact form dark mode overrides */
 [data-theme="dark"] form[name="contact"] {
-  --color-bg: #2a2a2e;
-  --color-text: #e2e8f0;
-  --color-muted: #b0b0b8;
-  --color-border: rgba(255, 255, 255, 0.1);
-  --color-border-2: rgba(255, 255, 255, 0.16);
-  --color-focus: #60a5fa;
+  --form-bg: #2a2a2e;
+  --form-text: #e2e8f0;
+  --form-muted: #b0b0b8;
+  --form-border: rgba(255, 255, 255, 0.1);
+  --form-border-2: rgba(255, 255, 255, 0.16);
+  --form-focus: #60a5fa;
 }
 
+/* Same values as [data-theme="dark"] above. Update both when changing dark colors. */
 @media (prefers-color-scheme: dark) {
   :root:not([data-theme="light"]) form[name="contact"] {
-    --color-bg: #2a2a2e;
-    --color-text: #e2e8f0;
-    --color-muted: #b0b0b8;
-    --color-border: rgba(255, 255, 255, 0.1);
-    --color-border-2: rgba(255, 255, 255, 0.16);
-    --color-focus: #60a5fa;
+    --form-bg: #2a2a2e;
+    --form-text: #e2e8f0;
+    --form-muted: #b0b0b8;
+    --form-border: rgba(255, 255, 255, 0.1);
+    --form-border-2: rgba(255, 255, 255, 0.16);
+    --form-focus: #60a5fa;
   }
 }
 
@@ -1731,15 +1736,3 @@ form[name="contact"] .check-row label {
   z-index: 1;
 }
 
-/* Navbar inner layout for toggle placement */
-#navbar .navbar-inner {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  height: 100%;
-}
-
-#navbar .navbar-inner ul {
-  display: flex;
-  align-items: center;
-}

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -800,6 +800,16 @@ div.full-section-btn {
   }
 }
 
+.video-embed {
+  display: block;
+  width: 100%;
+  max-width: 40em;
+  margin: 3em auto;
+  aspect-ratio: 16 / 9;
+  border: none;
+  border-radius: 8px;
+}
+
 /* Enlargeable images */
 /* WARN: The selector must match JS script */
 @media (hover: hover) {

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1705,16 +1705,15 @@ form[name="contact"] .check-row label {
   border: none;
   cursor: pointer;
   padding: 0.7em;
-  color: var(--color-navbar-link);
   display: flex;
   align-items: center;
   justify-content: center;
   border-radius: 4px;
-  transition: opacity 0.2s ease;
+  transition: filter 0.2s ease;
 }
 
 .theme-toggle-btn:hover {
-  opacity: 0.7;
+  filter: brightness(1.2);
 }
 
 .theme-toggle-btn svg {
@@ -1753,6 +1752,5 @@ form[name="contact"] .check-row label {
   right: 1em;
   background: rgba(255, 255, 255, 0.1);
   border-radius: 6px;
-  color: #ffffff;
   z-index: 1;
 }

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1,24 +1,81 @@
 /* TODO: Revamp font? Apparently the current implementation is suboptimal. */
 /* TODO: Move more values to variables like colors, breakpoints */
-/* TODO: Implement dark mode */
 
 /* @import url("https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,700,900"); */
 /* @import url("https://fonts.googleapis.com/css?family=Quicksand&display=swap"); */
 @import url("https://fonts.googleapis.com/css?family=Nunito+Sans:300,400&display=swap");
 
 :root {
+  color-scheme: light;
+
   --navbar-height: 7vh;
   --subnavbar-height: 5vh;
-  --navbar-link: #4f4f4f;
 
+  /* Brand colors — unchanged in dark mode */
   --color-blue: #145c9e;
-  --color-blue-text: #0b4f6c;
   --color-mint: #708b75;
   --color-graphite: #363636;
   --color-dark-blue: #062d3e;
   --color-darker-blue: #041c27;
   --color-purple: #7b1e7a;
   --color-lilac: #c2aff0;
+
+  /* Themeable tokens — light values */
+  --color-navbar-link: #4f4f4f;
+  --color-blue-text: #0b4f6c;
+  --color-bg: #ffffff;
+  --color-bg-surface: #f6f6f6;
+  --color-bg-footer: #f6f6f6;
+  --color-text-primary: #383838;
+  --color-text-secondary: #585858;
+  --color-text-link: #585858;
+  --color-border: #c9c9c9;
+  --color-border-light: #eeeeee;
+  --color-heading-green: #23751f;
+  --color-heading-blue: #0e4194;
+  --color-code-bg: rgba(144, 144, 144, 0.075);
+  --color-menu-overlay: rgba(255, 255, 255, 0.9);
+  --color-hamburger-bg: rgba(255, 255, 255, 0.5);
+}
+
+[data-theme="dark"] {
+  color-scheme: dark;
+  --color-navbar-link: #94b8c8;
+  --color-blue-text: #6fa0d8;
+  --color-bg: #1e1e22;
+  --color-bg-surface: #2a2a2e;
+  --color-bg-footer: #16161a;
+  --color-text-primary: #e2e8f0;
+  --color-text-secondary: #b0b0b8;
+  --color-text-link: #b0b0b8;
+  --color-border: #3a3a42;
+  --color-border-light: #2a2a2e;
+  --color-heading-green: #5aab55;
+  --color-heading-blue: #6fa0d8;
+  --color-code-bg: rgba(255, 255, 255, 0.06);
+  --color-menu-overlay: rgba(0, 0, 0, 0.7);
+  --color-hamburger-bg: rgba(0, 0, 0, 0.3);
+}
+
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme="light"]) {
+    color-scheme: dark;
+    --color-navbar-link: #94b8c8;
+    --color-blue-text: #6fa0d8;
+    --color-bg: #1e1e22;
+    --color-bg-surface: #2a2a2e;
+    --color-bg-footer: #16161a;
+    --color-text-primary: #e2e8f0;
+    --color-text-secondary: #b0b0b8;
+    --color-text-link: #b0b0b8;
+    --color-border: #3a3a42;
+    --color-border-light: #2a2a2e;
+    --color-heading-green: #5aab55;
+    --color-heading-blue: #6fa0d8;
+    --color-code-bg: rgba(255, 255, 255, 0.06);
+    --color-menu-overlay: rgba(0, 0, 0, 0.7);
+    --color-hamburger-bg: rgba(0, 0, 0, 0.3);
+  }
 }
 
 /* ---- Reset ---- */
@@ -58,7 +115,7 @@ html {
 }
 
 body {
-  background: #fff;
+  background: var(--color-bg);
 }
 
 /* Disable animations/transitions during preload */
@@ -76,7 +133,7 @@ input,
 label,
 select,
 textarea {
-  color: #383838;
+  color: var(--color-text-primary);
   /* font-family: "Source Sans Pro", Helvetica, sans-serif; */
   /* font-family: 'Quicksand', sans-serif; */
   font-family: "Nunito Sans", sans-serif;
@@ -86,7 +143,7 @@ textarea {
 }
 
 a {
-  color: #585858;
+  color: var(--color-text-link);
   text-decoration: none;
   transition:
     color 0.2s ease,
@@ -99,7 +156,7 @@ a:hover {
 }
 
 p > a {
-  border-bottom: dotted 1px rgb(176, 176, 176);
+  border-bottom: dotted 1px var(--color-border);
 }
 
 b {
@@ -151,7 +208,7 @@ h3 > a {
 
 h4 {
   font-size: medium;
-  color: #23751f;
+  color: var(--color-heading-green);
   margin-bottom: 0.75em;
   font-style: italic;
 }
@@ -199,16 +256,16 @@ sup {
 }
 
 blockquote {
-  border-left: solid 4px #c9c9c9;
+  border-left: solid 4px var(--color-border);
   font-style: italic;
   margin: 0 0 2em 0;
   padding: 0.5em 0 0.5em 2em;
 }
 
 code {
-  background: rgba(144, 144, 144, 0.075);
+  background: var(--color-code-bg);
   border-radius: 4px;
-  border: solid 1px #c9c9c9;
+  border: solid 1px var(--color-border);
   font-family: "Courier New", monospace;
   font-size: small;
   margin: 0 0.25em;
@@ -230,7 +287,7 @@ pre code {
 
 hr {
   border: 0;
-  border-bottom: solid 1px #c9c9c9;
+  border-bottom: solid 1px var(--color-border);
 }
 
 /* List */
@@ -264,13 +321,13 @@ table {
   width: 100%;
 
   & tbody tr {
-    border: solid 1px #c9c9c9;
+    border: solid 1px var(--color-border);
     border-left: 0;
     border-right: 0;
   }
 
   & tbody tr:nth-child(2n + 1) {
-    background-color: rgba(144, 144, 144, 0.075);
+    background-color: var(--color-code-bg);
   }
 
   & td {
@@ -315,8 +372,8 @@ table {
   position: sticky;
   margin: 0;
   text-align: center;
-  background: #fff;
-  border-bottom: 1px solid #eee;
+  background: var(--color-bg);
+  border-bottom: 1px solid var(--color-border-light);
   z-index: 10;
 }
 #navbar {
@@ -350,7 +407,7 @@ table {
 
 #navbar a,
 #subnavbar a {
-  color: #4f4f4f;
+  color: var(--color-navbar-link);
   border-bottom: 0;
 }
 
@@ -361,7 +418,7 @@ table {
 /* ---- Footer ---- */
 
 #footer {
-  background: #f6f6f6;
+  background: var(--color-bg-footer);
   padding: 1.5em 0;
   margin-top: 3em;
 
@@ -376,7 +433,7 @@ table {
 
   .copyright {
     margin: auto;
-    color: rgba(88, 88, 88, 1);
+    color: var(--color-text-secondary);
   }
 
   .icons {
@@ -393,7 +450,7 @@ table {
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    border: solid 1px #c9c9c9;
+    border: solid 1px var(--color-border);
     border-radius: 4px;
     transition:
       background-color 0.2s ease-in-out,
@@ -406,7 +463,19 @@ table {
     height: 25px;
     display: block;
   }
+}
 
+[data-theme="dark"] #footer .icons img {
+  filter: invert(1) brightness(0.85);
+}
+
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme="light"]) #footer .icons img {
+    filter: invert(1) brightness(0.85);
+  }
+}
+
+#footer {
   .icons a:hover,
   .icons a:focus-visible {
     border-color: #4b7bec;
@@ -675,7 +744,7 @@ div.full-section-btn {
 
 .row h3 {
   font-size: clamp(1rem, 1.8vw, 1.3rem);
-  color: #0e4194;
+  color: var(--color-heading-blue);
   margin-bottom: 0.5em;
 }
 .row h4 {
@@ -808,7 +877,7 @@ div.tiles-or-card-row {
   gap: 1vh;
 }
 div.project-card {
-  border: 1px solid #c4c4c4;
+  border: 1px solid var(--color-border);
   border-radius: 0.5rem;
   box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1);
 
@@ -844,7 +913,7 @@ div.project-card > div {
 div.project-card > div > p {
   margin: 0.4em 0 0.75em 0;
   line-height: 1.5;
-  color: rgb(55, 65, 81);
+  color: var(--color-text-secondary);
 
   @media screen and (max-width: 480px) {
     font-size: small;
@@ -1049,7 +1118,7 @@ div.project-card__more-btn {
       content: "";
       position: absolute;
       inset: 0;
-      background: var(--tile-color, #000);
+      background: var(--color-tile, #000);
       opacity: 0;
       transition: opacity 0.5s ease;
       pointer-events: none;
@@ -1115,9 +1184,9 @@ body.is-preload .affiliated-tiles-grid .affiliated-tile {
   height: 3em;
   line-height: 3em;
   padding: 0 1.5em;
-  background-color: rgba(255, 255, 255, 0.5);
+  background-color: var(--color-hamburger-bg);
   border-radius: 4px;
-  border: solid 1px #c9c9c9;
+  border: solid 1px var(--color-border);
   font-size: 0.8em;
   font-weight: 900;
   letter-spacing: 0.35em;
@@ -1160,6 +1229,32 @@ body.is-preload .affiliated-tiles-grid .affiliated-tile {
 #side-menu-btn nav ul li a[href="#menu"]:hover:after {
   opacity: 0;
 }
+
+/* Dark mode: light-stroke hamburger SVG data-URIs */
+/* Dark mode: light-stroke close button SVG data-URIs */
+[data-theme="dark"] #menu > .close:after {
+  background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='100' height='100' viewBox='0 0 100 100' preserveAspectRatio='none'%3E%3Cstyle%3Eline %7B stroke-width: 8px%3B stroke: %23cccccc%3B %7D%3C/style%3E%3Cline x1='15' y1='15' x2='85' y2='85' /%3E%3Cline x1='85' y1='15' x2='15' y2='85' /%3E%3C/svg%3E");
+}
+[data-theme="dark"] #menu > .close:before {
+  background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='100' height='100' viewBox='0 0 100 100' preserveAspectRatio='none'%3E%3Cstyle%3Eline %7B stroke-width: 8px%3B stroke: %2368a1ff%3B %7D%3C/style%3E%3Cline x1='15' y1='15' x2='85' y2='85' /%3E%3Cline x1='85' y1='15' x2='15' y2='85' /%3E%3C/svg%3E");
+}
+
+[data-theme="dark"] #side-menu-btn nav ul li a[href="#menu"]:before {
+  background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='100' height='100' viewBox='0 0 100 100' preserveAspectRatio='none'%3E%3Cstyle%3Eline %7B stroke-width: 8px%3B stroke: %23cccccc%3B %7D%3C/style%3E%3Cline x1='0' y1='25' x2='100' y2='25' /%3E%3Cline x1='0' y1='50' x2='100' y2='50' /%3E%3Cline x1='0' y1='75' x2='100' y2='75' /%3E%3C/svg%3E");
+}
+[data-theme="dark"] #side-menu-btn nav ul li a[href="#menu"]:after {
+  background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='100' height='100' viewBox='0 0 100 100' preserveAspectRatio='none'%3E%3Cstyle%3Eline %7B stroke-width: 8px%3B stroke: %23aaaaaa%3B %7D%3C/style%3E%3Cline x1='0' y1='25' x2='100' y2='25' /%3E%3Cline x1='0' y1='50' x2='100' y2='50' /%3E%3Cline x1='0' y1='75' x2='100' y2='75' /%3E%3C/svg%3E");
+}
+
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme="light"]) #side-menu-btn nav ul li a[href="#menu"]:before {
+    background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='100' height='100' viewBox='0 0 100 100' preserveAspectRatio='none'%3E%3Cstyle%3Eline %7B stroke-width: 8px%3B stroke: %23cccccc%3B %7D%3C/style%3E%3Cline x1='0' y1='25' x2='100' y2='25' /%3E%3Cline x1='0' y1='50' x2='100' y2='50' /%3E%3Cline x1='0' y1='75' x2='100' y2='75' /%3E%3C/svg%3E");
+  }
+  :root:not([data-theme="light"]) #side-menu-btn nav ul li a[href="#menu"]:after {
+    background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='100' height='100' viewBox='0 0 100 100' preserveAspectRatio='none'%3E%3Cstyle%3Eline %7B stroke-width: 8px%3B stroke: %23aaaaaa%3B %7D%3C/style%3E%3Cline x1='0' y1='25' x2='100' y2='25' /%3E%3Cline x1='0' y1='50' x2='100' y2='50' /%3E%3Cline x1='0' y1='75' x2='100' y2='75' /%3E%3C/svg%3E");
+  }
+}
+
 @media screen and (max-width: 736px) {
   #side-menu-btn nav ul li a[href="#menu"]:before,
   #side-menu-btn nav ul li a[href="#menu"]:after {
@@ -1308,7 +1403,7 @@ body::before {
   content: "";
   position: fixed;
   inset: 0;
-  background: rgba(255, 255, 255, 0.9);
+  background: var(--color-menu-overlay);
   z-index: 10001;
 
   /* Hide by default */
@@ -1388,19 +1483,19 @@ body.is-menu-visible #menu .close {
 
 /* Contact form */
 form[name="contact"] {
-  --bg: #fff;
-  --text: #111827;
-  --muted: #6b7280;
-  --border: rgba(17, 24, 39, 0.14);
-  --border2: rgba(17, 24, 39, 0.22);
-  --focus: #2563eb;
-  --ring: rgba(37, 99, 235, 0.18);
+  --color-bg: #fff;
+  --color-text: #111827;
+  --color-muted: #6b7280;
+  --color-border: rgba(17, 24, 39, 0.14);
+  --color-border-2: rgba(17, 24, 39, 0.22);
+  --color-focus: #2563eb;
+  --color-ring: rgba(37, 99, 235, 0.18);
 
   margin: 0 auto 2rem;
   padding: 1.25rem;
-  background: var(--bg);
-  color: var(--text);
-  border: 1px solid var(--border);
+  background: var(--color-bg);
+  color: var(--color-text);
+  border: 1px solid var(--color-border);
   border-radius: 14px;
   box-shadow: 0 12px 28px rgba(0, 0, 0, 0.08);
 }
@@ -1433,10 +1528,10 @@ form[name="contact"] textarea {
   width: 100%;
   box-sizing: border-box;
   padding: 0.7rem 0.85rem;
-  border: 1px solid var(--border2);
+  border: 1px solid var(--color-border-2);
   border-radius: 10px;
-  background: #fff;
-  color: var(--text);
+  background: var(--color-bg);
+  color: var(--color-text);
   outline: 0;
   transition:
     border-color 0.15s ease,
@@ -1450,13 +1545,13 @@ form[name="contact"] textarea {
 
 form[name="contact"] input::placeholder,
 form[name="contact"] textarea::placeholder {
-  color: var(--muted);
+  color: var(--color-muted);
 }
 
 form[name="contact"] input[type="text"]:focus-visible,
 form[name="contact"] textarea:focus-visible {
-  border-color: var(--focus);
-  box-shadow: 0 0 0 4px var(--ring);
+  border-color: var(--color-focus);
+  box-shadow: 0 0 0 4px var(--color-ring);
 }
 
 form[name="contact"] td:nth-child(2) input[type="checkbox"] {
@@ -1465,7 +1560,7 @@ form[name="contact"] td:nth-child(2) input[type="checkbox"] {
 }
 form[name="contact"] td:nth-child(2) input[type="checkbox"] + label {
   font-weight: 500;
-  color: var(--text);
+  color: var(--color-text);
 }
 form[name="contact"] td:nth-child(2) br {
   line-height: 1.7;
@@ -1535,4 +1630,110 @@ form[name="contact"] .check-row label {
 /* NOTE: This will not be used by a local dev server */
 .g-recaptcha > div {
   margin: 0 auto 1em auto;
+}
+
+/* Contact form dark mode overrides */
+[data-theme="dark"] form[name="contact"] {
+  --color-bg: #2a2a2e;
+  --color-text: #e2e8f0;
+  --color-muted: #b0b0b8;
+  --color-border: rgba(255, 255, 255, 0.1);
+  --color-border-2: rgba(255, 255, 255, 0.16);
+}
+
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme="light"]) form[name="contact"] {
+    --color-bg: #2a2a2e;
+    --color-text: #e2e8f0;
+    --color-muted: #b0b0b8;
+    --color-border: rgba(255, 255, 255, 0.1);
+    --color-border-2: rgba(255, 255, 255, 0.16);
+  }
+}
+
+/* ---- Theme toggle button ---- */
+
+.theme-toggle-btn {
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 0.4em;
+  color: var(--color-navbar-link);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 4px;
+  transition: opacity 0.2s ease;
+}
+
+.theme-toggle-btn:hover {
+  opacity: 0.7;
+}
+
+.theme-toggle-btn svg {
+  width: 1.2em;
+  height: 1.2em;
+  display: block;
+}
+
+.theme-toggle-btn .icon-sun {
+  display: none;
+}
+.theme-toggle-btn .icon-moon {
+  display: block;
+}
+
+[data-theme="dark"] .theme-toggle-btn .icon-sun {
+  display: block;
+}
+[data-theme="dark"] .theme-toggle-btn .icon-moon {
+  display: none;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme="light"]) .theme-toggle-btn .icon-sun {
+    display: block;
+  }
+  :root:not([data-theme="light"]) .theme-toggle-btn .icon-moon {
+    display: none;
+  }
+}
+
+/* Navbar inner layout for toggle placement */
+#navbar .navbar-inner {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  position: relative;
+}
+
+#navbar .navbar-inner ul {
+  display: flex;
+  align-items: center;
+}
+
+#navbar .navbar-toggle-slot {
+  position: absolute;
+  right: 1em;
+  top: 50%;
+  transform: translateY(-50%);
+}
+
+/* Side menu theme toggle row */
+li.theme-toggle-row {
+  display: flex;
+  align-items: center;
+  padding: 0.75em 0;
+  border-top: solid 1px rgba(255, 255, 255, 0.15);
+  gap: 0.75em;
+}
+
+li.theme-toggle-row label {
+  color: inherit;
+  font-size: 0.9em;
+}
+
+li.theme-toggle-row .theme-toggle-btn {
+  color: #ffffff;
 }

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1508,7 +1508,6 @@ form[name="contact"] {
   --color-border: rgba(17, 24, 39, 0.14);
   --color-border-2: rgba(17, 24, 39, 0.22);
   --color-focus: #2563eb;
-  --color-ring: rgba(37, 99, 235, 0.18);
 
   margin: 0 auto 2rem;
   padding: 1.25rem;
@@ -1570,7 +1569,7 @@ form[name="contact"] textarea::placeholder {
 form[name="contact"] input[type="text"]:focus-visible,
 form[name="contact"] textarea:focus-visible {
   border-color: var(--color-focus);
-  box-shadow: 0 0 0 4px var(--color-ring);
+  box-shadow: 0 0 0 4px var(--color-focus-ring);
 }
 
 form[name="contact"] td:nth-child(2) input[type="checkbox"] {
@@ -1610,7 +1609,7 @@ form[name="contact"] input[type="submit"]:hover {
 }
 form[name="contact"] input[type="submit"]:focus-visible {
   outline: none;
-  box-shadow: 0 0 0 3px rgba(29, 78, 216, 0.25);
+  box-shadow: 0 0 0 3px var(--color-focus-ring);
 }
 
 @media (max-width: 640px) {
@@ -1658,6 +1657,7 @@ form[name="contact"] .check-row label {
   --color-muted: #b0b0b8;
   --color-border: rgba(255, 255, 255, 0.1);
   --color-border-2: rgba(255, 255, 255, 0.16);
+  --color-focus: #60a5fa;
 }
 
 @media (prefers-color-scheme: dark) {
@@ -1667,6 +1667,7 @@ form[name="contact"] .check-row label {
     --color-muted: #b0b0b8;
     --color-border: rgba(255, 255, 255, 0.1);
     --color-border-2: rgba(255, 255, 255, 0.16);
+    --color-focus: #60a5fa;
   }
 }
 

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1099,6 +1099,7 @@ div.project-card__more-btn {
     place-items: center;
     border-radius: 0.5em;
     overflow: hidden;
+    box-shadow: 0 4px 20px var(--color-shadow-strong);
     width: 100%;
     aspect-ratio: 1;
     max-width: clamp(10rem, 20%, 18rem);

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1567,6 +1567,7 @@ form[name="contact"] textarea::placeholder {
 }
 
 form[name="contact"] input[type="text"]:focus-visible,
+form[name="contact"] input[type="email"]:focus-visible,
 form[name="contact"] textarea:focus-visible {
   border-color: var(--color-focus);
   box-shadow: 0 0 0 4px var(--color-focus-ring);

--- a/assets/html/navbar.html
+++ b/assets/html/navbar.html
@@ -12,3 +12,37 @@
   <li><a href="/hobbies/index.html" class="hobbies">Hobbies</a></li>
   <li><a href="/contact.html" class="contact">Contact</a></li>
 </ul>
+<button class="theme-toggle-btn" aria-label="Toggle dark mode">
+  <svg
+    class="icon-sun"
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    stroke-width="2"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+  >
+    <circle cx="12" cy="12" r="5"></circle>
+    <line x1="12" y1="1" x2="12" y2="3"></line>
+    <line x1="12" y1="21" x2="12" y2="23"></line>
+    <line x1="4.22" y1="4.22" x2="5.64" y2="5.64"></line>
+    <line x1="18.36" y1="18.36" x2="19.78" y2="19.78"></line>
+    <line x1="1" y1="12" x2="3" y2="12"></line>
+    <line x1="21" y1="12" x2="23" y2="12"></line>
+    <line x1="4.22" y1="19.78" x2="5.64" y2="18.36"></line>
+    <line x1="18.36" y1="5.64" x2="19.78" y2="4.22"></line>
+  </svg>
+  <svg
+    class="icon-moon"
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    stroke-width="2"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+  >
+    <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path>
+  </svg>
+</button>

--- a/assets/html/navbar.html
+++ b/assets/html/navbar.html
@@ -1,16 +1,14 @@
 <head>
   <meta name="robots" content="noindex" />
 </head>
-<div class="navbar-inner">
-  <ul width="50%">
-    <li><a href="/index.html" class="index">Home</a></li>
-    <li>
-      <a href="/professional/index.html" class="professional">Professional</a>
-    </li>
-    <li>
-      <a href="/projects/index.html" class="projects">Projects</a>
-    </li>
-    <li><a href="/hobbies/index.html" class="hobbies">Hobbies</a></li>
-    <li><a href="/contact.html" class="contact">Contact</a></li>
-  </ul>
-</div>
+<ul width="50%">
+  <li><a href="/index.html" class="index">Home</a></li>
+  <li>
+    <a href="/professional/index.html" class="professional">Professional</a>
+  </li>
+  <li>
+    <a href="/projects/index.html" class="projects">Projects</a>
+  </li>
+  <li><a href="/hobbies/index.html" class="hobbies">Hobbies</a></li>
+  <li><a href="/contact.html" class="contact">Contact</a></li>
+</ul>

--- a/assets/html/navbar.html
+++ b/assets/html/navbar.html
@@ -1,14 +1,34 @@
 <head>
   <meta name="robots" content="noindex" />
 </head>
-<ul width="50%">
-  <li><a href="/index.html" class="index">Home</a></li>
-  <li>
-    <a href="/professional/index.html" class="professional">Professional</a>
-  </li>
-  <li>
-    <a href="/projects/index.html" class="projects">Projects</a>
-  </li>
-  <li><a href="/hobbies/index.html" class="hobbies">Hobbies</a></li>
-  <li><a href="/contact.html" class="contact">Contact</a></li>
-</ul>
+<div class="navbar-inner">
+  <ul width="50%">
+    <li><a href="/index.html" class="index">Home</a></li>
+    <li>
+      <a href="/professional/index.html" class="professional">Professional</a>
+    </li>
+    <li>
+      <a href="/projects/index.html" class="projects">Projects</a>
+    </li>
+    <li><a href="/hobbies/index.html" class="hobbies">Hobbies</a></li>
+    <li><a href="/contact.html" class="contact">Contact</a></li>
+  </ul>
+  <div class="navbar-toggle-slot">
+    <button class="theme-toggle-btn" aria-label="Toggle dark mode">
+      <svg class="icon-sun" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+        <circle cx="12" cy="12" r="5"></circle>
+        <line x1="12" y1="1" x2="12" y2="3"></line>
+        <line x1="12" y1="21" x2="12" y2="23"></line>
+        <line x1="4.22" y1="4.22" x2="5.64" y2="5.64"></line>
+        <line x1="18.36" y1="18.36" x2="19.78" y2="19.78"></line>
+        <line x1="1" y1="12" x2="3" y2="12"></line>
+        <line x1="21" y1="12" x2="23" y2="12"></line>
+        <line x1="4.22" y1="19.78" x2="5.64" y2="18.36"></line>
+        <line x1="18.36" y1="5.64" x2="19.78" y2="4.22"></line>
+      </svg>
+      <svg class="icon-moon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+        <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path>
+      </svg>
+    </button>
+  </div>
+</div>

--- a/assets/html/navbar.html
+++ b/assets/html/navbar.html
@@ -13,22 +13,4 @@
     <li><a href="/hobbies/index.html" class="hobbies">Hobbies</a></li>
     <li><a href="/contact.html" class="contact">Contact</a></li>
   </ul>
-  <div class="navbar-toggle-slot">
-    <button class="theme-toggle-btn" aria-label="Toggle dark mode">
-      <svg class="icon-sun" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-        <circle cx="12" cy="12" r="5"></circle>
-        <line x1="12" y1="1" x2="12" y2="3"></line>
-        <line x1="12" y1="21" x2="12" y2="23"></line>
-        <line x1="4.22" y1="4.22" x2="5.64" y2="5.64"></line>
-        <line x1="18.36" y1="18.36" x2="19.78" y2="19.78"></line>
-        <line x1="1" y1="12" x2="3" y2="12"></line>
-        <line x1="21" y1="12" x2="23" y2="12"></line>
-        <line x1="4.22" y1="19.78" x2="5.64" y2="18.36"></line>
-        <line x1="18.36" y1="5.64" x2="19.78" y2="4.22"></line>
-      </svg>
-      <svg class="icon-moon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-        <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path>
-      </svg>
-    </button>
-  </div>
 </div>

--- a/assets/html/navbar.html
+++ b/assets/html/navbar.html
@@ -43,6 +43,10 @@
     stroke-linecap="round"
     stroke-linejoin="round"
   >
-    <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" fill="#4b7bec" fill-opacity="0.15"></path>
+    <path
+      d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"
+      fill="#4b7bec"
+      fill-opacity="0.15"
+    ></path>
   </svg>
 </button>

--- a/assets/html/navbar.html
+++ b/assets/html/navbar.html
@@ -18,12 +18,12 @@
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 24 24"
     fill="none"
-    stroke="currentColor"
+    stroke="#e8a020"
     stroke-width="2"
     stroke-linecap="round"
     stroke-linejoin="round"
   >
-    <circle cx="12" cy="12" r="5"></circle>
+    <circle cx="12" cy="12" r="5" fill="#e8a020" fill-opacity="0.2"></circle>
     <line x1="12" y1="1" x2="12" y2="3"></line>
     <line x1="12" y1="21" x2="12" y2="23"></line>
     <line x1="4.22" y1="4.22" x2="5.64" y2="5.64"></line>
@@ -38,11 +38,11 @@
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 24 24"
     fill="none"
-    stroke="currentColor"
+    stroke="#4b7bec"
     stroke-width="2"
     stroke-linecap="round"
     stroke-linejoin="round"
   >
-    <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path>
+    <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" fill="#4b7bec" fill-opacity="0.15"></path>
   </svg>
 </button>

--- a/assets/html/side_menu.html
+++ b/assets/html/side_menu.html
@@ -44,7 +44,11 @@
       stroke-linecap="round"
       stroke-linejoin="round"
     >
-      <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" fill="#4b7bec" fill-opacity="0.15"></path>
+      <path
+        d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"
+        fill="#4b7bec"
+        fill-opacity="0.15"
+      ></path>
     </svg>
   </button>
   <div class="inner">

--- a/assets/html/side_menu.html
+++ b/assets/html/side_menu.html
@@ -19,12 +19,12 @@
       xmlns="http://www.w3.org/2000/svg"
       viewBox="0 0 24 24"
       fill="none"
-      stroke="currentColor"
+      stroke="#e8a020"
       stroke-width="2"
       stroke-linecap="round"
       stroke-linejoin="round"
     >
-      <circle cx="12" cy="12" r="5"></circle>
+      <circle cx="12" cy="12" r="5" fill="#e8a020" fill-opacity="0.2"></circle>
       <line x1="12" y1="1" x2="12" y2="3"></line>
       <line x1="12" y1="21" x2="12" y2="23"></line>
       <line x1="4.22" y1="4.22" x2="5.64" y2="5.64"></line>
@@ -39,12 +39,12 @@
       xmlns="http://www.w3.org/2000/svg"
       viewBox="0 0 24 24"
       fill="none"
-      stroke="currentColor"
+      stroke="#4b7bec"
       stroke-width="2"
       stroke-linecap="round"
       stroke-linejoin="round"
     >
-      <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path>
+      <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" fill="#4b7bec" fill-opacity="0.15"></path>
     </svg>
   </button>
   <div class="inner">

--- a/assets/html/side_menu.html
+++ b/assets/html/side_menu.html
@@ -14,7 +14,16 @@
 <!-- Menu -->
 <nav id="menu">
   <button class="theme-toggle-btn" aria-label="Toggle dark mode">
-    <svg class="icon-sun" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+    <svg
+      class="icon-sun"
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="2"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+    >
       <circle cx="12" cy="12" r="5"></circle>
       <line x1="12" y1="1" x2="12" y2="3"></line>
       <line x1="12" y1="21" x2="12" y2="23"></line>
@@ -25,7 +34,16 @@
       <line x1="4.22" y1="19.78" x2="5.64" y2="18.36"></line>
       <line x1="18.36" y1="5.64" x2="19.78" y2="4.22"></line>
     </svg>
-    <svg class="icon-moon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+    <svg
+      class="icon-moon"
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="2"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+    >
       <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path>
     </svg>
   </button>

--- a/assets/html/side_menu.html
+++ b/assets/html/side_menu.html
@@ -13,6 +13,22 @@
 </header>
 <!-- Menu -->
 <nav id="menu">
+  <button class="theme-toggle-btn" aria-label="Toggle dark mode">
+    <svg class="icon-sun" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+      <circle cx="12" cy="12" r="5"></circle>
+      <line x1="12" y1="1" x2="12" y2="3"></line>
+      <line x1="12" y1="21" x2="12" y2="23"></line>
+      <line x1="4.22" y1="4.22" x2="5.64" y2="5.64"></line>
+      <line x1="18.36" y1="18.36" x2="19.78" y2="19.78"></line>
+      <line x1="1" y1="12" x2="3" y2="12"></line>
+      <line x1="21" y1="12" x2="23" y2="12"></line>
+      <line x1="4.22" y1="19.78" x2="5.64" y2="18.36"></line>
+      <line x1="18.36" y1="5.64" x2="19.78" y2="4.22"></line>
+    </svg>
+    <svg class="icon-moon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+      <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path>
+    </svg>
+  </button>
   <div class="inner">
     <h2>Menu</h2>
     <ul>

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -154,12 +154,13 @@ document.querySelectorAll("form textarea").forEach(function (textarea) {
 
 // Theme toggle
 function initThemeToggle() {
-  document.querySelectorAll('.theme-toggle-btn').forEach(function(btn) {
-    btn.addEventListener('click', function() {
-      var current = document.documentElement.getAttribute('data-theme') || 'light';
-      var next = current === 'dark' ? 'light' : 'dark';
-      document.documentElement.setAttribute('data-theme', next);
-      localStorage.setItem('theme', next);
+  document.querySelectorAll(".theme-toggle-btn").forEach(function (btn) {
+    btn.addEventListener("click", function () {
+      var current =
+        document.documentElement.getAttribute("data-theme") || "light";
+      var next = current === "dark" ? "light" : "dark";
+      document.documentElement.setAttribute("data-theme", next);
+      localStorage.setItem("theme", next);
     });
   });
 }

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -62,6 +62,9 @@ async function initNavbars() {
 
     // Initialize menu after it's loaded
     initMenu();
+
+    // Wire theme toggle buttons
+    initThemeToggle();
   } catch (error) {
     console.error("Error loading navigation:", error);
   }
@@ -149,6 +152,18 @@ document.querySelectorAll("form textarea").forEach(function (textarea) {
   }
 });
 
+// Theme toggle
+function initThemeToggle() {
+  document.querySelectorAll('.theme-toggle-btn').forEach(function(btn) {
+    btn.addEventListener('click', function() {
+      var current = document.documentElement.getAttribute('data-theme') || 'light';
+      var next = current === 'dark' ? 'light' : 'dark';
+      document.documentElement.setAttribute('data-theme', next);
+      localStorage.setItem('theme', next);
+    });
+  });
+}
+
 // Menu functionality
 function initMenu() {
   const menu = document.getElementById("menu");
@@ -207,6 +222,13 @@ function initMenu() {
     event.stopPropagation();
     event.preventDefault();
     toggleMenu();
+  });
+
+  // Click outside menu to close
+  document.body.addEventListener("click", function () {
+    if (body.classList.contains("is-menu-visible")) {
+      hideMenu();
+    }
   });
 
   // Escape key to close menu

--- a/assets/js/theme-init.js
+++ b/assets/js/theme-init.js
@@ -1,0 +1,10 @@
+(function () {
+  var saved = localStorage.getItem('theme');
+  var prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+  // Use || not ?? for broad browser compatibility (Safari < 13.1 lacks ??)
+  // localStorage.getItem returns null when absent, so || is safe here
+  document.documentElement.setAttribute(
+    'data-theme',
+    saved || (prefersDark ? 'dark' : 'light')
+  );
+})();

--- a/assets/js/theme-init.js
+++ b/assets/js/theme-init.js
@@ -1,10 +1,10 @@
 (function () {
-  var saved = localStorage.getItem('theme');
-  var prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+  var saved = localStorage.getItem("theme");
+  var prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
   // Use || not ?? for broad browser compatibility (Safari < 13.1 lacks ??)
   // localStorage.getItem returns null when absent, so || is safe here
   document.documentElement.setAttribute(
-    'data-theme',
-    saved || (prefersDark ? 'dark' : 'light')
+    "data-theme",
+    saved || (prefersDark ? "dark" : "light"),
   );
 })();

--- a/baculicall.html
+++ b/baculicall.html
@@ -9,6 +9,7 @@
     />
     <meta name="description" content="Baculi Call" />
     <meta name="robots" content="noindex" />
+    <script src="/assets/js/theme-init.js"></script>
     <link rel="stylesheet" href="/assets/css/main.css" />
     <link rel="icon" href="/images/icons/favicon-50_w.webp" />
   </head>

--- a/contact.html
+++ b/contact.html
@@ -11,6 +11,7 @@
       name="description"
       content="Noah's Contact Information | Contact Form • Affiliations • Social Links"
     />
+    <script src="/assets/js/theme-init.js"></script>
     <link rel="stylesheet" href="/assets/css/main.css" />
     <link rel="icon" href="/images/icons/favicon-50_w.webp" />
   </head>

--- a/familytree.html
+++ b/familytree.html
@@ -11,6 +11,7 @@
       name="description"
       content="Mecija Family Tree | Interactive family tree created by Noah Baculi"
     />
+    <script src="/assets/js/theme-init.js"></script>
     <link rel="stylesheet" href="/assets/css/main.css" />
     <link rel="stylesheet" href="/assets/css/familytree.css" />
     <link rel="icon" href="/images/icons/favicon-50_w.webp" />

--- a/hobbies/diy.html
+++ b/hobbies/diy.html
@@ -11,6 +11,7 @@
       name="description"
       content="Noah's DIY | Finance • Automotive • Woodworking"
     />
+    <script src="/assets/js/theme-init.js"></script>
     <link rel="stylesheet" href="/assets/css/main.css" />
     <link rel="icon" href="/images/icons/favicon-50_w.webp" />
   </head>

--- a/hobbies/index.html
+++ b/hobbies/index.html
@@ -11,6 +11,7 @@
       name="description"
       content="Noah's Hobbies and Personal Interests | Learning • Music • Swim • Travel | Gallery"
     />
+    <script src="/assets/js/theme-init.js"></script>
     <link rel="stylesheet" href="/assets/css/main.css" />
     <link rel="icon" href="/images/icons/favicon-50_w.webp" />
   </head>

--- a/hobbies/music.html
+++ b/hobbies/music.html
@@ -8,6 +8,7 @@
       content="width=device-width, initial-scale=1, user-scalable=no"
     />
     <meta name="description" content="Noah's Music | Choir • Guitar" />
+    <script src="/assets/js/theme-init.js"></script>
     <link rel="stylesheet" href="/assets/css/main.css" />
     <link rel="icon" href="/images/icons/favicon-50_w.webp" />
   </head>

--- a/hobbies/tech.html
+++ b/hobbies/tech.html
@@ -8,6 +8,7 @@
       content="width=device-width, initial-scale=1, user-scalable=no"
     />
     <meta name="description" content="Noah's Tech Hobby" />
+    <script src="/assets/js/theme-init.js"></script>
     <link rel="stylesheet" href="/assets/css/main.css" />
     <link rel="icon" href="/images/icons/favicon-50_w.webp" />
   </head>

--- a/hobbies/travel.html
+++ b/hobbies/travel.html
@@ -11,6 +11,7 @@
       name="description"
       content="Noah's Travel | Relationships • Opportunity • Perspective"
     />
+    <script src="/assets/js/theme-init.js"></script>
     <link rel="stylesheet" href="/assets/css/main.css" />
     <link rel="icon" href="/images/icons/favicon-50_w.webp" />
   </head>

--- a/index.html
+++ b/index.html
@@ -11,6 +11,7 @@
       name="description"
       content="Software Engineer @ EnterpriseDB | PDX | Northwestern University Engineering | Professional • Projects • Hobbies • Contact"
     />
+    <script src="/assets/js/theme-init.js"></script>
     <link rel="stylesheet" href="/assets/css/main.css" />
     <link rel="icon" href="/images/icons/favicon-50_w.webp" />
   </head>

--- a/index.html
+++ b/index.html
@@ -11,6 +11,7 @@
       name="description"
       content="Software Engineer @ EnterpriseDB | PDX | Northwestern University Engineering | Professional • Projects • Hobbies • Contact"
     />
+    <!-- Must load before stylesheets to prevent flash of wrong theme -->
     <script src="/assets/js/theme-init.js"></script>
     <link rel="stylesheet" href="/assets/css/main.css" />
     <link rel="icon" href="/images/icons/favicon-50_w.webp" />

--- a/professional/aldras.html
+++ b/professional/aldras.html
@@ -224,10 +224,7 @@
         href="https://aldras.netlify.app/"
         target="_blank"
         rel="noopener noreferrer"
-        style="
-          --color-tile: rgb(153, 0, 0);
-          box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3);
-        "
+        style="--color-tile: rgb(153, 0, 0)"
       >
         <img src="/images/contact/contact_aldras.png" alt="" />
         <h2>Aldras Automation</h2>

--- a/professional/aldras.html
+++ b/professional/aldras.html
@@ -45,31 +45,11 @@
       <h5 class="align-center subpage" style="margin-bottom: 1em">
         Founder and Software Engineer, <i>2019 - 2021</i>
       </h5>
-      <div
-        style="
-          aspect-ratio: 16 / 9;
-          position: relative;
-          max-width: 40em;
-          margin: 3em auto;
-          min-height: 40vh;
-          border-radius: 8px;
-          overflow: hidden;
-        "
-      >
-        <iframe
-          src="https://player.vimeo.com/video/453110523?title=0&byline=0&portrait=0"
-          style="
-            position: absolute;
-            top: 0;
-            left: 0;
-            width: 100%;
-            height: 100%;
-            max-height: 70vh;
-          "
-          frameborder="0"
-          allow="autoplay; fullscreen"
-        ></iframe>
-      </div>
+      <iframe
+        class="video-embed"
+        src="https://player.vimeo.com/video/453110523?title=0&byline=0&portrait=0"
+        allow="autoplay; fullscreen"
+      ></iframe>
       <script src="https://player.vimeo.com/api/player.js"></script>
       <div class="row row--1fr-1fr" style="align-items: flex-end">
         <div class="row__text">

--- a/professional/aldras.html
+++ b/professional/aldras.html
@@ -11,6 +11,7 @@
       name="description"
       content="Noah's Work Experience @ Aldras | Founder and Software Engineer | Inspiration • Application • Business"
     />
+    <script src="/assets/js/theme-init.js"></script>
     <link rel="stylesheet" href="/assets/css/main.css" />
     <link rel="icon" href="/images/icons/favicon-50_w.webp" />
   </head>
@@ -224,7 +225,7 @@
         target="_blank"
         rel="noopener noreferrer"
         style="
-          --tile-color: rgb(153, 0, 0);
+          --color-tile: rgb(153, 0, 0);
           box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3);
         "
       >

--- a/professional/asme.html
+++ b/professional/asme.html
@@ -11,6 +11,7 @@
       name="description"
       content="Noah's Student Organization - ASME @ Northwestern University | Founder and President | Beginnings • Aeolus Hovercraft • Dromos Car"
     />
+    <script src="/assets/js/theme-init.js"></script>
     <link rel="stylesheet" href="/assets/css/main.css" />
     <link rel="icon" href="/images/icons/favicon-50_w.webp" />
   </head>
@@ -227,7 +228,7 @@
         href="https://sites.northwestern.edu/asme/"
         target="_blank"
         rel="noopener noreferrer"
-        style="--tile-color: #4e2a84"
+        style="--color-tile: #4e2a84"
       >
         <img src="/images/contact/contact_asme.jpg" alt="" />
         <h2>American Society of Mechanical Engineers</h2>

--- a/professional/caffinator.html
+++ b/professional/caffinator.html
@@ -11,6 +11,7 @@
       name="description"
       content="Noah's Design Project - Caffinator @ Northwestern University (2018) | Mobile device testing automation system | Client: Kranze Technology Solutions"
     />
+    <script src="/assets/js/theme-init.js"></script>
     <link rel="stylesheet" href="/assets/css/main.css" />
     <link rel="icon" href="/images/icons/favicon-50_w.webp" />
   </head>

--- a/professional/carium.html
+++ b/professional/carium.html
@@ -11,6 +11,7 @@
       name="description"
       content="Noah's Work Experience @ Carium | Software Engineering | 2022 - 2023"
     />
+    <script src="/assets/js/theme-init.js"></script>
     <link rel="stylesheet" href="/assets/css/main.css" />
     <link rel="icon" href="/images/icons/favicon-50_w.webp" />
   </head>

--- a/professional/enterprisedb.html
+++ b/professional/enterprisedb.html
@@ -54,42 +54,15 @@
       <hr class="mobile-only" />
       <div class="row row--1fr-1fr">
         <div class="row__media">
-          <div
-            style="
-              position: relative;
-              aspect-ratio: 16 / 9;
-              overflow: hidden;
-              border: 1px grey solid;
-              border-radius: 8px;
-            "
-          >
-            <iframe
-              width="560"
-              height="315"
-              src="https://www.youtube.com/embed/lcXZ62lAqrs?si=-5of7_6oVhTjspv7"
-              title="Presentation YouTube video"
-              frameborder="0"
-              allow="
-                accelerometer;
-                autoplay;
-                controls;
-                clipboard-write;
-                encrypted-media;
-                gyroscope;
-                picture-in-picture;
-                web-share;
-              "
-              referrerpolicy="strict-origin-when-cross-origin"
-              allowfullscreen
-              style="
-                position: absolute;
-                top: 0;
-                left: 0;
-                width: 100%;
-                height: 100%;
-              "
-            ></iframe>
-          </div>
+          <iframe
+            class="video-embed"
+            src="https://www.youtube.com/embed/lcXZ62lAqrs?si=-5of7_6oVhTjspv7"
+            title="Presentation YouTube video"
+            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+            referrerpolicy="strict-origin-when-cross-origin"
+            allowfullscreen
+            style="border: 1px grey solid"
+          ></iframe>
         </div>
         <div class="row__text">
           <h3>Leadership</h3>

--- a/professional/enterprisedb.html
+++ b/professional/enterprisedb.html
@@ -58,7 +58,15 @@
             class="video-embed"
             src="https://www.youtube.com/embed/lcXZ62lAqrs?si=-5of7_6oVhTjspv7"
             title="Presentation YouTube video"
-            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+            allow="
+              accelerometer;
+              autoplay;
+              clipboard-write;
+              encrypted-media;
+              gyroscope;
+              picture-in-picture;
+              web-share;
+            "
             referrerpolicy="strict-origin-when-cross-origin"
             allowfullscreen
             style="border: 1px grey solid"

--- a/professional/enterprisedb.html
+++ b/professional/enterprisedb.html
@@ -11,6 +11,7 @@
       name="description"
       content="Noah's Work Experience @ EnterpriseDB | Software Engineering | 2024 - Present"
     />
+    <script src="/assets/js/theme-init.js"></script>
     <link rel="stylesheet" href="/assets/css/main.css" />
     <link rel="icon" href="/images/icons/favicon-50_w.webp" />
   </head>

--- a/professional/index.html
+++ b/professional/index.html
@@ -13,6 +13,7 @@
       content="Noah's Portfolio and Work Experience | Engineering @ EnterpriseDB •Carium •
 			Salesforce • Aldras • Otis • ASME | Independent Projects"
     />
+    <script src="/assets/js/theme-init.js"></script>
     <link rel="stylesheet" href="/assets/css/main.css" />
     <link rel="icon" href="/images/icons/favicon-50_w.webp" />
   </head>

--- a/professional/itw.html
+++ b/professional/itw.html
@@ -11,6 +11,7 @@
       name="description"
       content="Noah's Work Experience @ Illinois Tool Works - E.H. Wachs (2018) | Operations Engineering Intern | Standard work development • Cross-training"
     />
+    <script src="/assets/js/theme-init.js"></script>
     <link rel="stylesheet" href="/assets/css/main.css" />
     <link rel="icon" href="/images/icons/favicon-50_w.webp" />
   </head>

--- a/professional/nanofluidics.html
+++ b/professional/nanofluidics.html
@@ -11,6 +11,7 @@
       name="description"
       content="Noah's Engineering Internship @ Boston University | Nanoscale Energy-Fluids Transport Research | Summer 2016"
     />
+    <script src="/assets/js/theme-init.js"></script>
     <link rel="stylesheet" href="/assets/css/main.css" />
     <link rel="icon" href="/images/icons/favicon-50_w.webp" />
   </head>

--- a/professional/science-camp.html
+++ b/professional/science-camp.html
@@ -11,6 +11,7 @@
       name="description"
       content="Noah's Community Center Science Camp (2015-2016) | Founder and Volunteer | Hands-on STEM activities for elementary students • Catapults • Propulsion cars"
     />
+    <script src="/assets/js/theme-init.js"></script>
     <link rel="stylesheet" href="/assets/css/main.css" />
     <link rel="icon" href="/images/icons/favicon-50_w.webp" />
   </head>

--- a/professional/trane.html
+++ b/professional/trane.html
@@ -11,6 +11,7 @@
       name="description"
       content="Noah's Work Experience @ Trane Technologies (2019) | Systems Engineering Co-Op | Automation scripts • NLP • Data visualization • Quality analysis"
     />
+    <script src="/assets/js/theme-init.js"></script>
     <link rel="stylesheet" href="/assets/css/main.css" />
     <link rel="icon" href="/images/icons/favicon-50_w.webp" />
   </head>

--- a/projects/desk-control-panel.html
+++ b/projects/desk-control-panel.html
@@ -11,6 +11,7 @@
       name="description"
       content="Noah's Desk Control Panel (2025) | Custom KVM hub with ESP32-C3 • HDMI/USB switching • Speaker routing • MOSFET power control • Rust firmware"
     />
+    <script src="/assets/js/theme-init.js"></script>
     <link rel="stylesheet" href="/assets/css/main.css" />
     <link rel="icon" href="/images/icons/favicon-50_w.webp" />
   </head>

--- a/projects/doc-tool.html
+++ b/projects/doc-tool.html
@@ -12,6 +12,7 @@
       name="description"
       content="Noah's Document Tool | Find and replace text in Word documents to generate multiple output .docx files from a template"
     />
+    <script src="/assets/js/theme-init.js"></script>
     <link rel="stylesheet" href="/assets/css/main.css" />
     <link rel="icon" href="/images/icons/favicon-50_w.webp" />
     <style>

--- a/projects/guitar-tab-generator.html
+++ b/projects/guitar-tab-generator.html
@@ -16,6 +16,7 @@
       rel="stylesheet"
       href="https://fonts.googleapis.com/css?family=Roboto Mono"
     />
+    <script src="/assets/js/theme-init.js"></script>
     <link rel="stylesheet" href="/assets/css/guitartab.css" />
     <link rel="icon" href="/images/icons/favicon-50_w.webp" />
     <script type="module" src="https://cdn.skypack.dev/twind/shim"></script>

--- a/projects/index.html
+++ b/projects/index.html
@@ -12,6 +12,7 @@
       name="description"
       content="Noah's Independent Projects | Guitar Tab Generator • Desk Control Panel • Pet Feeder • Random Laser Pointer • Aldras • Salesforce Galaxy"
     />
+    <script src="/assets/js/theme-init.js"></script>
     <link rel="stylesheet" href="/assets/css/main.css" />
     <link rel="icon" href="/images/icons/favicon-50_w.webp" />
   </head>

--- a/projects/pet-feeder.html
+++ b/projects/pet-feeder.html
@@ -11,6 +11,7 @@
       name="description"
       content="Noah's Automatic Pet Feeder (2023) | ESP32-based proximity sensing with Bluetooth tags • Servo-controlled door • Arduino C++ • Custom CAD enclosure"
     />
+    <script src="/assets/js/theme-init.js"></script>
     <link rel="stylesheet" href="/assets/css/main.css" />
     <link rel="icon" href="/images/icons/favicon-50_w.webp" />
   </head>

--- a/projects/random-laser-pointer.html
+++ b/projects/random-laser-pointer.html
@@ -11,6 +11,7 @@
       name="description"
       content="Noah's Random Laser Pointer (2024) | ESP32-C3 with dual servo motors for automated cat entertainment • Adjustable range • Rust firmware"
     />
+    <script src="/assets/js/theme-init.js"></script>
     <link rel="stylesheet" href="/assets/css/main.css" />
     <link rel="icon" href="/images/icons/favicon-50_w.webp" />
   </head>

--- a/test-results/.last-run.json
+++ b/test-results/.last-run.json
@@ -1,4 +1,0 @@
-{
-  "status": "failed",
-  "failedTests": []
-}

--- a/test-results/.last-run.json
+++ b/test-results/.last-run.json
@@ -1,0 +1,4 @@
+{
+  "status": "failed",
+  "failedTests": []
+}


### PR DESCRIPTION
Adds dark mode with a toggle in the side menu and system-preference detection.

- `theme-init.js` runs in `<head>` on every page to set `data-theme` before CSS loads, avoiding a flash of the wrong theme
- Hard-coded colors in `main.css`, `guitartab.css`, and `familytree.css` replaced with CSS custom properties that swap between light and dark palettes
- Theme toggle (sun/moon icons) wired into the side menu and navbar partial
- Video embeds on Aldras and EnterpriseDB pages simplified with a shared `.video-embed` class
- Dev server switched from live-server to browser-sync (live-server was truncating HTML partials)
